### PR TITLE
Possibility to localize external links

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -17,7 +17,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
         include:
           - python-version: 3.7
             tox-env: py37
@@ -27,6 +27,8 @@ jobs:
             tox-env: py39
           - python-version: "3.10"
             tox-env: py310
+          - python-version: "3.11"
+            tox-env: py311
     env:
       TOXENV: ${{ matrix.tox-env }}
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -488,6 +488,8 @@ Those context [variables can be accessed using Jinja2 notation](https://jinja.pa
 
 ## Using a folder per language structure
 
+:warning: The **folder structure feature is not as mature as the suffix one** and should be used only for large and complex translation layouts. The folder structure is also very strict about your `docs_dir` layout so make sure you respect it properly.
+
 The `mkdocs-static-i18n` plugin can be configured to work with a **language per folder based structure** where you create a folder per language your want to support translations for.
 
 For example, the given folder structure:

--- a/mkdocs_static_i18n/folder_structure.py
+++ b/mkdocs_static_i18n/folder_structure.py
@@ -344,7 +344,18 @@ def on_nav(self, nav, config, files):
             self.i18n_files[language], self.i18n_configs[language]
         )
         if manual_nav is False:
-            self.i18n_navs[language].items = self.i18n_navs[language].items[0].children
+            if self.i18n_navs[language].items[0].children is None:
+                # the structure is weird, say it but do not crash hard, see #152
+                log.warning(
+                    f"The structure of folder '{config['docs_dir']}/{language}' "
+                    "does not look right, expect navigation or url inconsistencies"
+                )
+            else:
+                # the expected folder structure starts with a [Section(title='LANG')]
+                # so we render our navigation using it as a root
+                self.i18n_navs[language].items = (
+                    self.i18n_navs[language].items[0].children
+                )
             for item in self.i18n_navs[language]:
                 if config["use_directory_urls"] is True:
                     expected_url = f"{language}/"

--- a/mkdocs_static_i18n/suffix_structure.py
+++ b/mkdocs_static_i18n/suffix_structure.py
@@ -243,11 +243,11 @@ class I18nFile(File):
         dirname, filename = os.path.split(url)
         if use_directory_urls and filename == "index.html":
             if dirname == "":
-                url = "."
+                url = "./"
             else:
                 url = dirname + "/"
         if self.dest_language:
-            if url == ".":
+            if url in [".", "./"]:
                 url = self.dest_language + "/"
             else:
                 url = self.dest_language + "/" + url

--- a/requirements-qa.txt
+++ b/requirements-qa.txt
@@ -2,4 +2,4 @@ black==22.10.0
 flake8==5.0.4; python_version > "3.7"
 flake8; python_version < "3.8"
 isort==5.10.1
-pytest==7.1.3
+pytest==7.2.0

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(fname):
 
 setup(
     name="mkdocs-static-i18n",
-    version="0.49",
+    version="0.50",
     author="Ultrabug",
     author_email="ultrabug@ultrabug.net",
     description="MkDocs i18n plugin using static translation markdown files",

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310}
+    py{37,38,39,310,311}
 
 [testenv:py37]
 passenv = LANG


### PR DESCRIPTION
Problem description:
- Multilingual website uses external links, included via the mkdocs `nav` configuration
- Some of these links differ from language to language, e.g., if website is displayed in English, the external link should (assuming localizations of the external website are available) also point to the English localization, if displayed in French, to the French localization

Solution proposal:
- Extend `nav_translations` with the option to include not only a translation string, but also a URL